### PR TITLE
현대카드 홈페이지 IE모드에서 삭제

### DIFF
--- a/docs/sites.xml
+++ b/docs/sites.xml
@@ -525,10 +525,6 @@
     <compat-mode>Default</compat-mode>
     <open-in>IE11</open-in>
   </site>
-  <site url="hyundaicard.com">
-    <compat-mode>Default</compat-mode>
-    <open-in>IE11</open-in>
-  </site>
   <site url="samsungcard.com">
     <compat-mode>Default</compat-mode>
     <open-in>IE11</open-in>


### PR DESCRIPTION
현대카드 더이상 IE 지원하지 않는 것을 확인하였습니다.